### PR TITLE
* add : missing methods, fields and properties.

### DIFF
--- a/Runtime/Debug.cs
+++ b/Runtime/Debug.cs
@@ -1,10 +1,18 @@
-﻿using System;
+#if !DEVELOPMENT_BUILD && !FORCE_LOGGING
+
+using System;
 using System.Diagnostics;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
 public static class Debug
 {
+    public static ILogger s_Logger = UnityEngine.Debug.unityLogger;
+    public static ILogger unityLogger
+    {
+        get { return UnityEngine.Debug.unityLogger; }
+    }
+    
     [Conditional("UNITY_EDITOR")]
     public static void Break() =>
         UnityEngine.Debug.Break();
@@ -80,4 +88,135 @@ public static class Debug
     [Conditional("UNITY_EDITOR")]
     public static void LogWarning(object message, Object context) => 
         UnityEngine.Debug.LogWarning(message,context);
+    
+    [Conditional("UNITY_EDITOR")]
+    public static void LogWarningFormat(string format, params object[] args)
+    {
+        UnityEngine.Debug.LogWarningFormat(format, args);
+    }
+
+    [Conditional("UNITY_EDITOR")]
+    public static void LogWarningFormat(Object context, string format, params object[] args)
+    {
+        UnityEngine.Debug.LogWarningFormat(context, format, args);
+    }
+    
+    [Conditional("UNITY_EDITOR")]
+    public static void LogFormat(string message, params object[] args) {
+        UnityEngine.Debug.LogFormat(message, args);
+    }
+
+    [Conditional("UNITY_EDITOR")]
+    public static void LogErrorFormat(string message, params object[] args) {
+        UnityEngine.Debug.LogErrorFormat(message, args);
+    }
+
+    [Conditional("UNITY_ASSERTIONS")]
+    [Conditional("UNITY_EDITOR")]
+    public static void Assert(bool condition)
+    {
+        UnityEngine.Debug.Assert(condition);
+    }
+
+    [Conditional("UNITY_ASSERTIONS")]
+    [Conditional("UNITY_EDITOR")]
+    public static void Assert(bool condition, Object context)
+    {
+        UnityEngine.Debug.Assert(condition, context);
+    }
+
+    [Conditional("UNITY_ASSERTIONS")]
+    [Conditional("UNITY_EDITOR")]
+    public static void Assert(bool condition, object message)
+    {
+        UnityEngine.Debug.Assert(condition, message);
+    }
+
+    [Conditional("UNITY_ASSERTIONS")]
+    [Conditional("UNITY_EDITOR")]
+    public static void Assert(bool condition, string message)
+    {
+        UnityEngine.Debug.Assert(condition, message);
+    }
+
+    [Conditional("UNITY_ASSERTIONS")]
+    [Conditional("UNITY_EDITOR")]
+    public static void Assert(bool condition, object message, Object context)
+    {
+        UnityEngine.Debug.Assert(condition, message, context);
+    }
+
+    [Conditional("UNITY_ASSERTIONS")]
+    [Conditional("UNITY_EDITOR")]
+    public static void Assert(bool condition, string message, Object context)
+    {
+        UnityEngine.Debug.Assert(condition, message, context);
+    }
+
+    [Conditional("UNITY_ASSERTIONS")]
+    [Conditional("UNITY_EDITOR")]
+    public static void AssertFormat(bool condition, string format, params object[] args)
+    {
+        UnityEngine.Debug.AssertFormat(condition, format, args);
+    }
+
+    [Conditional("UNITY_ASSERTIONS")]
+    [Conditional("UNITY_EDITOR")]
+    public static void AssertFormat(
+        bool condition,
+        Object context,
+        string format,
+        params object[] args)
+    {
+        UnityEngine.Debug.AssertFormat(condition, context, format, args);
+    }
+
+    [Conditional("UNITY_ASSERTIONS")]
+    [Conditional("UNITY_EDITOR")]
+    public static void LogAssertion(object message)
+    {
+        UnityEngine.Debug.LogAssertion(message);
+    }
+
+    [Conditional("UNITY_ASSERTIONS")]
+    [Conditional("UNITY_EDITOR")]
+    public static void LogAssertion(object message, Object context)
+    {
+        UnityEngine.Debug.LogAssertion(message, context);
+    }
+
+    [Conditional("UNITY_ASSERTIONS")]
+    [Conditional("UNITY_EDITOR")]
+    public static void LogAssertionFormat(string format, params object[] args)
+    {
+        UnityEngine.Debug.LogAssertionFormat(format, args);
+    }
+    
+    [Conditional("UNITY_ASSERTIONS")]
+    [Conditional("UNITY_EDITOR")]
+    public static void LogAssertionFormat(Object context, string format, params object[] args)
+    {
+        UnityEngine.Debug.LogAssertionFormat(context, format, args);
+    }
+    
+    public static bool isDebugBuild
+    {
+        get { return UnityEngine.Debug.isDebugBuild; }
+    }
+
+    [Conditional("UNITY_ASSERTIONS")]
+    [Conditional("UNITY_EDITOR")]
+    [Obsolete("Assert(bool, string, params object[]) is obsolete. Use AssertFormat(bool, string, params object[]) (UnityUpgradable) -> AssertFormat(*)", true)]
+    public static void Assert(bool condition, string format, params object[] args)
+    {
+        UnityEngine.Debug.Assert(condition, format, args);
+    }
+
+    [Obsolete("Debug.logger is obsolete. Please use Debug.unityLogger instead (UnityUpgradable) -> unityLogger")]
+    public static ILogger logger
+    {
+        get { return UnityEngine.Debug.logger; }
+    }
 }
+
+#endif


### PR DESCRIPTION
## 개요
Debug 클래스를 UnitTest나 Editor 상의 워크플로에서 다양하게 활용하는 프로젝트들의 경우 여러가지빌드 옵션에 따라 미 구현된 메서드와 필드, 프로퍼티들이 conflict 를 일으킵니다. 하는 김에 최종 사용자가 수정하지 않도록 wrapper 클래스로서의 역할을 다 하는게 좋겠습니다. 

+ unity-editor 외에 dev build, release build 에서 역시 debug 클래스를 사용하여야 하는 경우가 있습니다. 더구나 headless-server build 가 가능해진 지금, 옵션은 더 많을 것입니다. 그런 의미에서 DEVELOPMENT_BUILD 인 경우 로깅을 하도록 하는편이 좋습니다. 
+ release build 에서도 항상 로깅을 할 수 있도록 FORCE_LOGGING 전처리기를 추가했습니다. 
+ 스크립팅 심볼 정의는 MenuItem에서 관리하게끔 유틸리티를 만들어 사용해도 편리합니다. 하지만 MenuItem이 추가로 생기는 부분은 사용자 취향이기때문에 구현하지는 않았습니다.

### Original commit log

1. Several missing elements were implemented as functional.
2. Capsulized whole class by preprocessor to log on cooked client with development build.
3. Add optional force logging options for release build. if you add FORCE_LOGGING on Scripting Define Symbol in player setting of the project settings.